### PR TITLE
Using header-only version of fmt in static build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://github.com/mamba-org/powerloader/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patches/01-fmt.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [(win and vc<14) or py==36]
 
 requirements:

--- a/recipe/patches/01-fmt.patch
+++ b/recipe/patches/01-fmt.patch
@@ -1,0 +1,53 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b4d11cf1..5c821c7a 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -180,8 +180,7 @@ macro(libpowerloader_create_target target_name linkage deps_linkage output_name)
+ 
+     find_package(tl-expected REQUIRED)
+     find_package(spdlog REQUIRED)
+-
+-    set(SPDLOG_TARGET spdlog::spdlog_header_only)
++    find_package(fmt REQUIRED)
+ 
+     if (${deps_linkage_upper} STREQUAL "STATIC")
+         message("   -> Statically linking against libpowerloader (static) dependencies")
+@@ -242,7 +241,8 @@ macro(libpowerloader_create_target target_name linkage deps_linkage output_name)
+             target_link_libraries(${target_name}
+                 PUBLIC
+                     tl::expected
+-                    ${SPDLOG_TARGET}
++                    spdlog::spdlog_header_only
++                    fmt::fmt-header-only
+                     ${STATIC_DEPS}
+                     ${POWERLOADER_FORCE_DYNAMIC_LIBS}
+             )
+@@ -265,7 +265,8 @@ macro(libpowerloader_create_target target_name linkage deps_linkage output_name)
+                 ${CRYPTO_LIBRARIES}
+                 ${ZCHUNK_LIBRARY}
+                 zstd::libzstd_static
+-                ${SPDLOG_TARGET}
++                fmt::fmt-header-only
++                spdlog::spdlog_header_only
+             )
+ 
+             include_directories($ENV{CONDA_PREFIX}/Library/include/)
+@@ -284,7 +285,8 @@ macro(libpowerloader_create_target target_name linkage deps_linkage output_name)
+         target_link_libraries(${target_name}
+             PUBLIC
+                 tl::expected
+-                ${SPDLOG_TARGET}
++                fmt::fmt
++                spdlog::spdlog_header_only
+             PRIVATE
+                 ${CURL_LIBRARIES}
+                 ${ZCK_LIBRARY}
+@@ -345,7 +347,7 @@ endif ()
+ 
+ if (BUILD_EXE)
+     add_executable(powerloader ${POWERLOADER_SOURCE_DIR}/cli/main.cpp)
+-    if (WIN32 AND BUILD_STATIC)
++    if (WIN32 AND NOT BUILD_SHARED)
+         set_target_properties(powerloader PROPERTIES MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+     endif()
+ 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
